### PR TITLE
rename default FxM signal column name [breaking]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ after_success:
   # push coverage results to Codecov
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
 
+# only build the master branch since all other branches will have PRs associated
+# with them. See https://github.com/travis-ci/travis-ci/issues/1147#issuecomment-160820262
+branches:
+  only:
+    - "master"
+
 jobs:
   allow_failures:
     - julia: nightly

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FluorescenceExclusion"
 uuid = "b1480678-572a-4d60-ab1d-db2f300f29c9"
 authors = ["Tamas Nagy <github@tamasnagy.com>"]
-version = "0.1.3"
+version = "0.2.0"
 
 [deps]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"

--- a/src/denoise.jl
+++ b/src/denoise.jl
@@ -24,10 +24,15 @@ function denoise(filepath; cores=Sys.CPU_THREADS)
     # denoise image using NDSAFIR
     dn_mrc = replace(mrc_filepath, ".mrc" => "_dn.mrc")
     @info "Denoising $filename)"
-    cmd = `ndsafir_priism "$mrc_filepath" "$dn_mrc" -iter=4 -np=$cores -3d=t -noise=poisson -adapt=10.0 -island=4.0 -p=1 -sampling=-1`
+    cmd = `ndsafir_priism "$mrc_filepath" "$dn_mrc" -iter=4 -np=$cores -3d=t -noise=poisson -usetmp -adapt=10.0 -island=4.0 -p=1 -sampling=-1`
     run(pipeline(cmd, stdout=outfile, stderr=outfile, append=true))
 
     dn_tiff = replace(dn_mrc, "_dn.mrc" => "_dn.tiff")
     @info "Converting $filename back to tif"
     run(`mrc2tiff "$dn_mrc" -single -out="$dn_tiff"`)
+
+    @info "Cleaning up..."
+    rm(mrc_filepath)
+    rm(dn_mrc)
+    rm(outfile)
 end

--- a/src/particles.jl
+++ b/src/particles.jl
@@ -76,7 +76,7 @@ end
 function build_tp_df(img::AxisArray{T1, 3},
                      thresholds::AxisArray{T2, 3}; dist=(2, 10)) where {T1, T2 <: Bool}
     build_tp_df(AxisArray(reshape(img, size(img)..., 1),
-                          AxisArrays.axes(img)..., Axis{:channel}([:slice])),
+                          AxisArrays.axes(img)..., Axis{:channel}([:FxM])),
                 thresholds;
                 dist=dist
                )
@@ -95,7 +95,7 @@ function build_tp_df(img::AxisArray{T1, 3},
                      thresholds::AxisArray{T2, 3}; dist=(2, 10)) where {T1, T2 <: Integer}
 
     build_tp_df(AxisArray(reshape(img, size(img)..., 1),
-                          AxisArrays.axes(img)..., Axis{:channel}([:slice])),
+                          AxisArrays.axes(img)..., Axis{:channel}([:FxM])),
                 thresholds;
                 dist=dist
                )

--- a/src/tracking.jl
+++ b/src/tracking.jl
@@ -24,9 +24,9 @@ function link(img, labels; dist=(3, 12), chamber_height=12.96μm)
     ystepsize = step(AxisArrays.axes(img, Axis{:y}).val)
 
     # compute the maximum intensity value for each cell's background
-    Imax = linked[:, :medbkg_slice]
+    Imax = linked[:, :medbkg_FxM]
 
-    rel_vols = (linked[!, :medbkg_slice] .* linked[!, :area]) .- linked[!, :tf_slice];
+    rel_vols = (linked[!, :medbkg_FxM] .* linked[!, :area]) .- linked[!, :tf_FxM];
     insertcols!(linked, 6, :rel_volume => rel_vols)
 
     # α is the maximum signal per voxel


### PR DESCRIPTION
The original name didn't make a lot of sense and made it trickier for downstream assays. Making the default name be FxM is much better going forward.